### PR TITLE
Create ZephyrSyncService.java

### DIFF
--- a/zephyr-sync-core/src/main/java/lv/ctco/zephyr/ZephyrSyncService.java
+++ b/zephyr-sync-core/src/main/java/lv/ctco/zephyr/ZephyrSyncService.java
@@ -46,6 +46,12 @@ public class ZephyrSyncService {
         }
 
         zephyrService.linkExecutionsToTestCycle(metaInfo, testCases);
+        // needed to update correcty status of test cases
+        try {
+            TimeUnit.SECONDS.sleep(1);
+        } catch (InterruptedException e) {
+            System.out.print("Error not catched ! ");
+        }
         zephyrService.updateExecutionStatuses(testCases);
 
     }


### PR DESCRIPTION
In the case of a creation for the first time of a new cycle, the reporting of tests cases is reported in all the time as "Not executed". By adding this wait, the service zephyrService.updateExecutionStatuses (testCases) responds correctly